### PR TITLE
Add skeleton loaders and motion-aware animations

### DIFF
--- a/src/components/Dashboard/CategoryHierarchyView.tsx
+++ b/src/components/Dashboard/CategoryHierarchyView.tsx
@@ -14,8 +14,9 @@ import {
   Badge,
   Tooltip,
   IconButton,
-  LinearProgress
+  Skeleton
 } from '@mui/material';
+import { keyframes } from '@emotion/react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
@@ -71,6 +72,11 @@ const CategoryHierarchyView: React.FC<CategoryHierarchyViewProps> = ({
   loading
 }) => {
   const [expandedCategories, setExpandedCategories] = useState<Record<number, boolean>>({});
+
+  const fadeIn = keyframes`
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: none; }
+  `;
 
   // Filter top-level categories for current industry
   const topLevelCategories = categories.filter(
@@ -138,14 +144,22 @@ const CategoryHierarchyView: React.FC<CategoryHierarchyViewProps> = ({
     
     return (
       <React.Fragment key={category.id}>
-        <ListItem 
+        <ListItem
           button
           selected={isSelected}
           onClick={() => onSelectCategory(category.id)}
-          sx={{ 
+          sx={{
             pl: 2 + level * 2,
             borderLeft: isSelected ? `4px solid ${category.color_code || '#1976d2'}` : 'none',
             bgcolor: isSelected ? 'rgba(25, 118, 210, 0.08)' : 'transparent',
+            opacity: 0,
+            transform: 'translateY(4px)',
+            animation: `${fadeIn} 0.3s ease forwards`,
+            '@media (prefers-reduced-motion: reduce)': {
+              animation: 'none',
+              opacity: 1,
+              transform: 'none'
+            },
             '&:hover': {
               bgcolor: 'rgba(25, 118, 210, 0.04)',
             }
@@ -246,10 +260,15 @@ const CategoryHierarchyView: React.FC<CategoryHierarchyViewProps> = ({
         
         {loading ? (
           <Box sx={{ px: 2, py: 1 }}>
-            <LinearProgress />
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              Loading categories...
-            </Typography>
+            {[...Array(5)].map((_, i) => (
+              <Skeleton
+                key={i}
+                variant="rectangular"
+                height={40}
+                animation="wave"
+                sx={{ mb: 1, borderRadius: 1 }}
+              />
+            ))}
           </Box>
         ) : (
           <List dense component="nav" sx={{ maxHeight: 500, overflow: 'auto' }}>

--- a/src/components/News/CategoryNewsSection.tsx
+++ b/src/components/News/CategoryNewsSection.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import { 
   Box, 
   Typography, 
-  Grid, 
-  Divider, 
-  CircularProgress, 
+  Grid,
+  Divider,
   Alert,
   useTheme,
-  Button,
-  Skeleton
+  Button
 } from '@mui/material';
 import NewsCard from './NewsCard';
 import { useNewsByProcedureCategory, NewsArticle } from '../../services/newsService';
@@ -131,9 +129,13 @@ const CategoryNewsSection: React.FC<CategoryNewsSectionProps> = ({
       <Divider sx={{ mb: 2 }} />
       
       {loading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-          <CircularProgress />
-        </Box>
+        <Grid container spacing={3}>
+          {[1, 2, 3].map((n) => (
+            <Grid item xs={12} sm={6} md={4} key={n}>
+              <NewsCard industry={industry} loading />
+            </Grid>
+          ))}
+        </Grid>
       ) : error ? (
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}

--- a/src/components/News/NewsCard.tsx
+++ b/src/components/News/NewsCard.tsx
@@ -1,26 +1,27 @@
 import React from 'react';
-import { 
-  Card, 
-  CardContent, 
-  CardMedia, 
-  Typography, 
-  Box, 
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Box,
   Chip,
-  Link,
-  CardActionArea
+  CardActionArea,
+  Skeleton
 } from '@mui/material';
 import { format, parseISO } from 'date-fns';
 
 interface NewsCardProps {
-  id: number;
-  title: string;
-  summary: string;
+  id?: number;
+  title?: string;
+  summary?: string;
   image_url?: string;
-  published_date: string;
-  source: string;
+  published_date?: string;
+  source?: string;
   author?: string;
   url?: string;
   industry: 'dental' | 'aesthetic';
+  loading?: boolean;
 }
 
 const NewsCard: React.FC<NewsCardProps> = ({
@@ -31,7 +32,8 @@ const NewsCard: React.FC<NewsCardProps> = ({
   published_date,
   url,
   industry,
-  author
+  author,
+  loading = false
 }) => {
   // Format the date
   const formattedDate = published_date ? 
@@ -64,44 +66,58 @@ const NewsCard: React.FC<NewsCardProps> = ({
   };
 
   return (
-    <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <CardActionArea 
-        component="a" 
-        href={isValidUrl(url) ? url : '#'} 
-        target="_blank" 
-        rel="noopener noreferrer"
-        onClick={handleCardClick}>
-
-        <CardMedia
-          component="img"
-          height="140"
-          image={image_url || defaultImage}
-          alt={title}
-        />
-        <CardContent sx={{ flexGrow: 1 }}>
-          <Typography gutterBottom variant="h6" component="h2" sx={{ fontWeight: 'bold', mb: 1 }}>
-            {title}
-          </Typography>
-          
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {summary}
-          </Typography>
-          
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 'auto' }}>
-            <Typography variant="caption" color="text.secondary">
-              {source} • {formattedDate}
+    <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column', opacity: 0, transform: 'translateY(4px)', animation: 'fadeIn 0.3s ease forwards', '@media (prefers-reduced-motion: reduce)': { animation: 'none', opacity: 1, transform: 'none' } }}>
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(4px); }
+          to { opacity: 1; transform: none; }
+        }
+      `}</style>
+      {loading ? (
+        <>
+          <Skeleton variant="rectangular" height={140} animation="wave" />
+          <CardContent sx={{ flexGrow: 1 }}>
+            <Skeleton variant="text" height={28} sx={{ mb: 1 }} />
+            <Skeleton variant="text" sx={{ mb: 1 }} />
+            <Skeleton variant="text" width="60%" />
+          </CardContent>
+        </>
+      ) : (
+        <CardActionArea
+          component="a"
+          href={isValidUrl(url) ? url : '#'}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleCardClick}
+        >
+          <CardMedia
+            component="img"
+            height="140"
+            image={image_url || defaultImage}
+            alt={title}
+          />
+          <CardContent sx={{ flexGrow: 1 }}>
+            <Typography gutterBottom variant="h6" component="h2" sx={{ fontWeight: 'bold', mb: 1 }}>
+              {title}
             </Typography>
-            
-            <Chip 
-              label={industry === 'dental' ? 'Dental' : 'Aesthetic'} 
-              size="small" 
-              color={industry === 'dental' ? 'primary' : 'secondary'}
-              variant="outlined"
-              sx={{ ml: 1 }}
-            />
-          </Box>
-        </CardContent>
-      </CardActionArea>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {summary}
+            </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 'auto' }}>
+              <Typography variant="caption" color="text.secondary">
+                {source} • {formattedDate}
+              </Typography>
+              <Chip
+                label={industry === 'dental' ? 'Dental' : 'Aesthetic'}
+                size="small"
+                color={industry === 'dental' ? 'primary' : 'secondary'}
+                variant="outlined"
+                sx={{ ml: 1 }}
+              />
+            </Box>
+          </CardContent>
+        </CardActionArea>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
## Summary
- add fade-in animations and list skeleton placeholders
- add NewsCard skeleton variant and use it during news loading
- respect `prefers-reduced-motion`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing modules)*