### PR TITLE
Apply gradient theme to dashboard and news

### DIFF
--- a/src/assets/OrbContextProvider.tsx
+++ b/src/assets/OrbContextProvider.tsx
@@ -1,4 +1,6 @@
 import React, { createContext, useContext, useState, useMemo } from 'react';
+import { useTheme } from '@mui/material/styles';
+import { ORB_GRADIENT } from '../context/ThemeContext';
 
 // Define the type for the orb context
 interface OrbContextType {
@@ -16,7 +18,7 @@ interface ColorModeContextType {
 
 // Create the Orb context
 const OrbContext = createContext<OrbContextType>({
-  gradientColors: { start: '#00ffc6', end: '#7B42F6' }
+  gradientColors: ORB_GRADIENT
 });
 
 // Create the color mode context
@@ -28,6 +30,7 @@ const ColorModeContext = createContext<ColorModeContextType>({
 export const OrbContextProvider = ({ children }: { children: React.ReactNode }) => {
   // State for color mode
   const [mode, setMode] = useState<'light' | 'dark'>('dark');
+  const theme = useTheme();
   
   // Color mode toggle function
   const colorMode = useMemo(
@@ -40,9 +43,9 @@ export const OrbContextProvider = ({ children }: { children: React.ReactNode }) 
     [mode],
   );
 
-  // Orb context values
+  // Orb context values pulled from the theme
   const orbValues = {
-    gradientColors: { start: '#00ffc6', end: '#7B42F6' }
+    gradientColors: (theme as any).customGradients?.orb || ORB_GRADIENT
   };
 
   return (

--- a/src/components/Dashboard/DashboardFixed.tsx
+++ b/src/components/Dashboard/DashboardFixed.tsx
@@ -24,6 +24,7 @@ import {
   Tooltip,
   Badge
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import { visuallyHidden } from '@mui/utils';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
@@ -40,6 +41,13 @@ const Dashboard: React.FC = () => {
   const [aestheticProcedures, setAestheticProcedures] = useState<any[]>([]);
   const [dentalCompanies, setDentalCompanies] = useState<any[]>([]);
   const [aestheticCompanies, setAestheticCompanies] = useState<any[]>([]);
+
+  const theme = useTheme();
+  const orbGradient = (theme as any).customGradients?.orb || { start: '#00ffc6', end: '#7B42F6' };
+  const gradientBorder = {
+    borderTop: '3px solid',
+    borderImage: `linear-gradient(90deg, ${orbGradient.start}, ${orbGradient.end}) 1`
+  };
   
   // State for categories - both legacy and new hierarchical system
   const [dentalCategories, setDentalCategories] = useState<DentalCategory[]>([]);
@@ -597,7 +605,7 @@ const Dashboard: React.FC = () => {
         {/* Main content area */}
         <Grid item xs={12} md={9}>
           {/* Procedures section */}
-          <Card variant="outlined" sx={{ mb: 3 }}>
+          <Card variant="outlined" sx={{ mb: 3, ...gradientBorder }}>
             <CardContent>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
                 <Typography variant="h6" color="primary" gutterBottom>
@@ -784,7 +792,7 @@ const Dashboard: React.FC = () => {
           </Card>
           
           {/* Companies section */}
-          <Card variant="outlined">
+          <Card variant="outlined" sx={gradientBorder}>
             <CardContent>
               <Typography variant="h6" color="primary" gutterBottom>
                 {selectedIndustry === 'dental' ? 'Dental' : 'Aesthetic'} Companies

--- a/src/components/Dashboard/DashboardNew.tsx
+++ b/src/components/Dashboard/DashboardNew.tsx
@@ -24,6 +24,7 @@ import {
   LinearProgress,
   Tooltip
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { supabase } from '../../services/supabaseClient';
 import { DentalCategory, AestheticCategory } from '../../types';
 
@@ -109,6 +110,13 @@ const Dashboard: React.FC = () => {
   const [aestheticProcedures, setAestheticProcedures] = useState<AestheticProcedure[]>([]);
   const [dentalCompanies, setDentalCompanies] = useState<Company[]>([]);
   const [aestheticCompanies, setAestheticCompanies] = useState<Company[]>([]);
+
+  const theme = useTheme();
+  const orbGradient = (theme as any).customGradients?.orb || { start: '#00ffc6', end: '#7B42F6' };
+  const gradientBorder = {
+    borderTop: '3px solid',
+    borderImage: `linear-gradient(90deg, ${orbGradient.start}, ${orbGradient.end}) 1`
+  };
   
   // State for categories
   const [dentalCategories, setDentalCategories] = useState<DentalCategory[]>([]);
@@ -571,7 +579,7 @@ const Dashboard: React.FC = () => {
 
       {/* Industry Toggle Switch */}
       <Box sx={{ display: 'flex', justifyContent: 'center', mb: 4 }}>
-        <Card elevation={3} sx={{ px: 4, py: 2, borderRadius: 2 }}>
+        <Card elevation={3} sx={{ px: 4, py: 2, borderRadius: 2, ...gradientBorder }}>
           <Grid container alignItems="center" spacing={2}>
             <Grid item>
               <Typography 
@@ -610,7 +618,7 @@ const Dashboard: React.FC = () => {
       {selectedCategory && (
         <Grid container spacing={3} sx={{ mb: 4 }}>
           <Grid item xs={12}>
-            <Card elevation={3} sx={{ bgcolor: selectedIndustry === 'dental' ? '#e3f2fd' : '#fce4ec' }}>
+            <Card elevation={3} sx={{ bgcolor: selectedIndustry === 'dental' ? '#e3f2fd' : '#fce4ec', ...gradientBorder }}>
               <CardContent>
                 <Typography variant="h6" gutterBottom>
                   {selectedIndustry === 'dental' 
@@ -619,7 +627,7 @@ const Dashboard: React.FC = () => {
                 </Typography>
                 <Grid container spacing={2}>
                   <Grid item xs={12} md={4}>
-                    <Card variant="outlined" sx={{ height: '100%' }}>
+                    <Card variant="outlined" sx={{ height: '100%', ...gradientBorder }}>
                       <CardContent>
                         <Typography variant="subtitle2" color="text.secondary">Market Size</Typography>
                         <Typography variant="h5">
@@ -631,7 +639,7 @@ const Dashboard: React.FC = () => {
                     </Card>
                   </Grid>
                   <Grid item xs={12} md={4}>
-                    <Card variant="outlined" sx={{ height: '100%' }}>
+                    <Card variant="outlined" sx={{ height: '100%', ...gradientBorder }}>
                       <CardContent>
                         <Typography variant="subtitle2" color="text.secondary">Growth Rate</Typography>
                         <Typography variant="h5">
@@ -643,7 +651,7 @@ const Dashboard: React.FC = () => {
                     </Card>
                   </Grid>
                   <Grid item xs={12} md={4}>
-                    <Card variant="outlined" sx={{ height: '100%' }}>
+                    <Card variant="outlined" sx={{ height: '100%', ...gradientBorder }}>
                       <CardContent>
                         <Typography variant="subtitle2" color="text.secondary">Procedure Count</Typography>
                         <Typography variant="h5">
@@ -664,7 +672,7 @@ const Dashboard: React.FC = () => {
       {/* Category Distribution Visualization */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
         <Grid item xs={12}>
-          <Card elevation={3}>
+          <Card elevation={3} sx={gradientBorder}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
                 {selectedIndustry === 'dental' ? 'Dental Category Distribution' : 'Aesthetic Category Distribution'}
@@ -823,7 +831,7 @@ const Dashboard: React.FC = () => {
       {/* Categories Section */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
         <Grid item xs={12}>
-          <Card elevation={3}>
+          <Card elevation={3} sx={gradientBorder}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
                 {selectedIndustry === 'dental' ? 'Dental Procedure Categories' : 'Aesthetic Procedure Categories'}
@@ -885,7 +893,7 @@ const Dashboard: React.FC = () => {
       {/* Procedures Section */}
       <Grid container spacing={3} sx={{ mb: 4 }} id="procedures-section">
         <Grid item xs={12}>
-          <Card elevation={3}>
+          <Card elevation={3} sx={gradientBorder}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
                 {selectedIndustry === 'dental' ? 'Dental Procedures' : 'Aesthetic Procedures'}
@@ -990,7 +998,7 @@ const Dashboard: React.FC = () => {
       {/* Companies Section */}
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Card elevation={3}>
+          <Card elevation={3} sx={gradientBorder}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
                 {selectedIndustry === 'dental' ? 'Dental Companies' : 'Aesthetic Companies'}

--- a/src/components/News/CategoryNewsSection.tsx
+++ b/src/components/News/CategoryNewsSection.tsx
@@ -94,13 +94,18 @@ const mockAestheticNews: NewsArticle[] = [
   }
 ];
 
-const CategoryNewsSection: React.FC<CategoryNewsSectionProps> = ({ 
-  categoryId, 
-  categoryName, 
+const CategoryNewsSection: React.FC<CategoryNewsSectionProps> = ({
+  categoryId,
+  categoryName,
   industry,
   limit = 3
 }) => {
   const theme = useTheme();
+  const orbGradient = (theme as any).customGradients?.orb || { start: '#00ffc6', end: '#7B42F6' };
+  const gradientBorder = {
+    borderBottom: '2px solid',
+    borderImage: `linear-gradient(90deg, ${orbGradient.start}, ${orbGradient.end}) 1`
+  };
   
   // Use the custom hook to fetch news by procedure category
   const { 
@@ -122,13 +127,11 @@ const CategoryNewsSection: React.FC<CategoryNewsSectionProps> = ({
 
   return (
     <Box sx={{ mb: 4 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, pb: 1, ...gradientBorder }}>
         <Typography variant="h6" component="h3">
           {categoryName}
         </Typography>
       </Box>
-      
-      <Divider sx={{ mb: 2 }} />
       
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
@@ -160,10 +163,15 @@ const CategoryNewsSection: React.FC<CategoryNewsSectionProps> = ({
           )}
           {displayArticles.length > 0 && (
             <Box sx={{ mt: 2, textAlign: 'center' }}>
-              <Button 
-                variant="outlined" 
-                color="primary" 
-                sx={{ borderRadius: theme.shape.borderRadius, mt: 2 }}
+              <Button
+                variant="contained"
+                sx={{
+                  borderRadius: theme.shape.borderRadius,
+                  mt: 2,
+                  background: `linear-gradient(90deg, ${orbGradient.start}, ${orbGradient.end})`,
+                  color: '#fff',
+                  '&:hover': { background: `linear-gradient(90deg, ${orbGradient.end}, ${orbGradient.start})` }
+                }}
                 onClick={() => console.log('View More button clicked')}
               >
                 View More {categoryName} News

--- a/src/components/News/NewsCard.tsx
+++ b/src/components/News/NewsCard.tsx
@@ -9,6 +9,7 @@ import {
   Link,
   CardActionArea
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { format, parseISO } from 'date-fns';
 
 interface NewsCardProps {
@@ -33,6 +34,12 @@ const NewsCard: React.FC<NewsCardProps> = ({
   industry,
   author
 }) => {
+  const theme = useTheme();
+  const orbGradient = (theme as any).customGradients?.orb || { start: '#00ffc6', end: '#7B42F6' };
+  const gradientBorder = {
+    borderTop: '3px solid',
+    borderImage: `linear-gradient(90deg, ${orbGradient.start}, ${orbGradient.end}) 1`
+  };
   // Format the date
   const formattedDate = published_date ? 
     (typeof published_date === 'string' ? 
@@ -64,7 +71,7 @@ const NewsCard: React.FC<NewsCardProps> = ({
   };
 
   return (
-    <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column', ...gradientBorder }}>
       <CardActionArea 
         component="a" 
         href={isValidUrl(url) ? url : '#'} 

--- a/src/components/News/NewsDashboard.tsx
+++ b/src/components/News/NewsDashboard.tsx
@@ -9,6 +9,7 @@ import {
   CircularProgress,
   Alert
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import CategoryNewsSection from './CategoryNewsSection';
 import { useTopProcedureCategoriesWithNews, ProcedureCategory } from '../../services/newsService';
 
@@ -90,6 +91,12 @@ const mockAestheticCategories: ProcedureCategory[] = [
 
 const NewsDashboard: React.FC = () => {
   const [tabValue, setTabValue] = useState(0);
+  const theme = useTheme();
+  const orbGradient = (theme as any).customGradients?.orb || { start: '#00ffc6', end: '#7B42F6' };
+  const gradientBorder = {
+    borderTop: '3px solid',
+    borderImage: `linear-gradient(90deg, ${orbGradient.start}, ${orbGradient.end}) 1`
+  };
   
   // Fetch dental categories using the custom hook
   const { 
@@ -134,7 +141,7 @@ const NewsDashboard: React.FC = () => {
   }
 
   return (
-    <Paper sx={{ mb: 4, borderRadius: 2, overflow: 'hidden' }}>
+    <Paper sx={{ mb: 4, borderRadius: 2, overflow: 'hidden', ...gradientBorder }}>
       <Box sx={{ p: 3, pb: 0 }}>
         <Typography variant="h4" component="h1" gutterBottom sx={{ fontWeight: 'bold' }}>
           Industry News

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -12,8 +12,9 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 // Common theme settings
+export const ORB_GRADIENT = { start: '#00ffc6', end: '#7B42F6' } as const;
 const getTheme = (mode: ThemeMode): Theme => {
-  const ACCENT_COLOR = '#00ffc6';
+  const ACCENT_COLOR = ORB_GRADIENT.start;
   
   return createTheme({
     palette: {
@@ -32,6 +33,10 @@ const getTheme = (mode: ThemeMode): Theme => {
         primary: mode === 'light' ? 'rgba(0, 0, 0, 0.87)' : 'rgba(255, 255, 255, 0.87)',
         secondary: mode === 'light' ? 'rgba(0, 0, 0, 0.6)' : 'rgba(255, 255, 255, 0.6)',
       },
+    },
+    // Custom property for shared gradients
+    customGradients: {
+      orb: ORB_GRADIENT
     },
     typography: {
       fontFamily: [
@@ -90,7 +95,7 @@ const getTheme = (mode: ThemeMode): Theme => {
         },
       },
     },
-  });
+  } as any);
 };
 
 interface ThemeProviderProps {


### PR DESCRIPTION
## Summary
- centralize orb gradient in `ThemeContext`
- feed theme gradient to `OrbContextProvider`
- add gradient styles to dashboard cards
- update news sections and cards with gradient borders

## Testing
- `npm run lint` *(fails: ESLint config missing)*