### PR TITLE
Implement realtime news via Brave API

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,4 @@ REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXB
 REACT_APP_API_URL=https://osbackend-zl1h.onrender.com
 
 
+BRAVE_SEARCH_API_KEY=BSA9AzPzmrTcPfaAxx0keBgoelvQoMp

--- a/render.yaml
+++ b/render.yaml
@@ -13,3 +13,5 @@ services:
         value: https://cbopynuvhcymbumjnvay.supabase.co
       - key: SUPABASE_ANON_KEY
         value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNib3B5bnV2aGN5bWJ1bWpudmF5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODQ0MzI3OTEsImV4cCI6MTk5OTgzMjc5MX0.1YQbIj2-aXXFSYUXvPiEIBDJccy7mOC-wnuP5HpYA0Y
+      - key: BRAVE_SEARCH_API_KEY
+        value: BSA9AzPzmrTcPfaAxx0keBgoelvQoMp

--- a/src/components/News/RealtimeNewsSection.tsx
+++ b/src/components/News/RealtimeNewsSection.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Grid,
+  CircularProgress,
+  Alert
+} from '@mui/material';
+import NewsCard from './NewsCard';
+import { useRealtimeNewsByProcedure } from '../../services/newsService';
+
+interface RealtimeNewsSectionProps {
+  procedureId: string;
+  procedureName: string;
+  industry: 'dental' | 'aesthetic';
+  limit?: number;
+}
+
+const RealtimeNewsSection: React.FC<RealtimeNewsSectionProps> = ({
+  procedureId,
+  procedureName,
+  industry,
+  limit = 5
+}) => {
+  const { articles, loading, error } = useRealtimeNewsByProcedure(procedureId, limit);
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h6" component="h3" sx={{ mb: 2 }}>
+        Latest News on {procedureName}
+      </Typography>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      ) : (
+        <Grid container spacing={3}>
+          {articles.map((article) => (
+            <Grid item xs={12} sm={6} md={4} key={article.id}>
+              <NewsCard {...article} industry={industry} />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+    </Box>
+  );
+};
+
+export default RealtimeNewsSection;


### PR DESCRIPTION
## Summary
- add Brave Search key in env files
- update Render config to expose the new key
- create an endpoint `/api/news/realtime/:procedureId` in the Express proxy
- introduce `useRealtimeNewsByProcedure` hook
- add `RealtimeNewsSection` component to display latest articles

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*