### PR TITLE
Implement basic Supabase auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+node_modules
+.env.local
+

--- a/login.html
+++ b/login.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Log In</title>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/login.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.16",
     "@mui/material": "^5.15.16",
+    "@supabase/supabase-js": "^2.42.5",
     "axios": "^1.9.0",
     "date-fns": "^4.1.0",
     "react": "^18.2.0",

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign Up</title>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/signup.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,20 @@ import Dashboard from './components/Dashboard/DashboardFixed';
 import { OrbContextProvider } from './assets/OrbContextProvider';
 import NavBar from './assets/menubar';
 import { ThemeProvider } from './context/ThemeContext';
+import { AuthProvider } from './context/AuthContext';
+import AuthGate from './components/AuthGate';
 
 const App: React.FC = () => {
   return (
     <ThemeProvider>
-      <OrbContextProvider>
-        <NavBar />
-        <Dashboard />
-      </OrbContextProvider>
+      <AuthProvider>
+        <OrbContextProvider>
+          <NavBar />
+          <AuthGate>
+            <Dashboard />
+          </AuthGate>
+        </OrbContextProvider>
+      </AuthProvider>
     </ThemeProvider>
   );
 };

--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Button } from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+
+const AuthGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user } = useAuth();
+
+  if (!user) {
+    return (
+      <Box position="relative">
+        <Box sx={{ filter: 'blur(4px)', pointerEvents: 'none' }}>{children}</Box>
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            bgcolor: 'rgba(0,0,0,0.6)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fff',
+            p: 2,
+          }}
+        >
+          <p>Please log in to view this content.</p>
+          <Button variant="contained" href="/login.html">Log In</Button>
+        </Box>
+      </Box>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default AuthGate;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../services/supabaseClient';
+
+interface AuthContextType {
+  user: User | null;
+  session: Session | null;
+  signIn: (email: string, password: string) => Promise<{ error: any } | { data: any }>;
+  signUp: (email: string, password: string) => Promise<{ error: any } | { data: any }>;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+    });
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      setSession(newSession);
+      setUser(newSession?.user ?? null);
+    });
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const value: AuthContextType = {
+    user,
+    session,
+    signIn: (email, password) => supabase.auth.signInWithPassword({ email, password }),
+    signUp: (email, password) => supabase.auth.signUp({ email, password }),
+    signOut: () => supabase.auth.signOut().then(() => { /* no-op */ }),
+  };
+
+  return (
+    <AuthContext.Provider value={value}>
+      {!loading && children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextType => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};

--- a/src/login.tsx
+++ b/src/login.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { ThemeProvider } from './context/ThemeContext';
+import { AuthProvider } from './context/AuthContext';
+import LoginPage from './pages/LoginPage';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <ThemeProvider>
+        <AuthProvider>
+          <LoginPage />
+        </AuthProvider>
+      </ThemeProvider>
+    </React.StrictMode>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+
+const LoginPage: React.FC = () => {
+  const { signIn } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await signIn(email, password) as any;
+    if (error) {
+      setError(error.message);
+    } else {
+      window.location.href = '/';
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400, mx: 'auto', mt: 8 }}>
+      <Typography variant="h5" gutterBottom>Log In</Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+        <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+        {error && <Typography color="error">{error}</Typography>}
+        <Button type="submit" variant="contained">Log In</Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+
+const SignupPage: React.FC = () => {
+  const { signUp } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await signUp(email, password) as any;
+    if (error) {
+      setError(error.message);
+    } else {
+      window.location.href = '/';
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400, mx: 'auto', mt: 8 }}>
+      <Typography variant="h5" gutterBottom>Sign Up</Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+        <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+        {error && <Typography color="error">{error}</Typography>}
+        <Button type="submit" variant="contained">Sign Up</Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default SignupPage;

--- a/src/signup.tsx
+++ b/src/signup.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { ThemeProvider } from './context/ThemeContext';
+import { AuthProvider } from './context/AuthContext';
+import SignupPage from './pages/SignupPage';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <ThemeProvider>
+        <AuthProvider>
+          <SignupPage />
+        </AuthProvider>
+      </ThemeProvider>
+    </React.StrictMode>
+  );
+}


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js` dependency
- ignore `.env.local`
- build `AuthProvider` context for Supabase session
- gate dashboard behind login
- create login and signup pages with Vite entry points

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: dependencies not installed in this environment)*