### PR TITLE
Add Brave search integration

### DIFF
--- a/src/assets/menubar.tsx
+++ b/src/assets/menubar.tsx
@@ -25,11 +25,13 @@ import Brightness7Icon from '@mui/icons-material/Brightness7';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import SearchIcon from '@mui/icons-material/Search';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
 import LoginModal from '../components/Auth/LoginModal';
 import SignupModal from '../components/Auth/SignupModal';
 import LogoutModal from '../components/Auth/LogoutModal';
+import SuperSearch from '../components/Search/SuperSearch';
 import { useAuth } from '../context/AuthContext';
 
 const ACCENT_COLOR = '#00ffc6';
@@ -108,6 +110,7 @@ export default function NavBar() {
   const [loginOpen, setLoginOpen] = React.useState(false);
   const [signupOpen, setSignupOpen] = React.useState(false);
   const [logoutOpen, setLogoutOpen] = React.useState(false);
+  const [searchOpen, setSearchOpen] = React.useState(false);
   const { user } = useAuth();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -448,14 +451,17 @@ export default function NavBar() {
           gap: { xs: 0.5, sm: 1 },
         }}>
           {/* Theme Toggle - Subtle but visible */}
-          <Box sx={{
-            display: 'flex',
-            alignItems: 'center',
-            mr: 1,
-            opacity: 0.8,
-          }}>
-            <ThemeToggle />
-          </Box>
+        <Box sx={{
+          display: 'flex',
+          alignItems: 'center',
+          mr: 1,
+          opacity: 0.8,
+        }}>
+          <ThemeToggle />
+          <IconButton color="inherit" size="small" onClick={() => setSearchOpen(true)} sx={{ ml: 1 }}>
+            <SearchIcon />
+          </IconButton>
+        </Box>
           
           {/* Auth Buttons - Always visible except on very small screens */}
           <Box sx={{
@@ -576,6 +582,7 @@ export default function NavBar() {
     <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
     <SignupModal open={signupOpen} onClose={() => setSignupOpen(false)} />
     <LogoutModal open={logoutOpen} onClose={() => setLogoutOpen(false)} />
+    <SuperSearch open={searchOpen} onClose={() => setSearchOpen(false)} />
     </>
   );
 }

--- a/src/components/Search/SuperSearch.tsx
+++ b/src/components/Search/SuperSearch.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  IconButton,
+  InputAdornment,
+  List,
+  ListItem,
+  ListItemText,
+  CircularProgress,
+  Box
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import SearchIcon from '@mui/icons-material/Search';
+import braveSearchService from '../../services/braveSearchService';
+
+interface SuperSearchProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SuperSearch: React.FC<SuperSearchProps> = ({ open, onClose }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSearch = async () => {
+    if (!query.trim()) return;
+    setLoading(true);
+    try {
+      const data = await braveSearchService.search(query);
+      setResults(data.results || []);
+    } catch (err) {
+      console.error('Brave search failed', err);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        Super Search
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <TextField
+          autoFocus
+          fullWidth
+          placeholder="Search..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton onClick={handleSearch} edge="end" disabled={loading}>
+                  {loading ? <CircularProgress size={20} /> : <SearchIcon />}
+                </IconButton>
+              </InputAdornment>
+            )
+          }}
+        />
+        <Box sx={{ mt: 2 }}>
+          <List>
+            {results.map((item, idx) => (
+              <ListItem key={idx} component="a" href={item.url} target="_blank" divider button>
+                <ListItemText primary={item.title} secondary={item.description} />
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SuperSearch;

--- a/src/services/braveSearchService.ts
+++ b/src/services/braveSearchService.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const NEWS_PROXY_URL = process.env.NODE_ENV === 'production'
+  ? 'https://repspheres-news-proxy.onrender.com'
+  : 'http://localhost:3001';
+
+export async function search(query: string, limit: number = 10): Promise<any> {
+  const response = await axios.get(`${NEWS_PROXY_URL}/api/search/brave`, {
+    params: { query, limit }
+  });
+  return response.data;
+}
+
+export default { search };


### PR DESCRIPTION
## Summary
- create backend route to proxy Brave search API
- add braveSearchService client
- build SuperSearch component to query Brave search
- add search modal access from NavBar

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*