### PR TITLE
Fix category bars scaling

### DIFF
--- a/src/components/Dashboard/MarketSizeOverview.tsx
+++ b/src/components/Dashboard/MarketSizeOverview.tsx
@@ -84,8 +84,12 @@ export const MarketSizeOverview: React.FC<MarketSizeOverviewProps> = ({
   );
   
   // Calculate total market size
-  const totalMarketSize = useMemo(() =>
-    currentProcedures.reduce((sum, p) => sum + (p.market_size_usd_millions || 0), 0),
+  const totalMarketSize = useMemo(
+    () =>
+      currentProcedures.reduce(
+        (sum, p) => sum + (Number(p.market_size_usd_millions) || 0),
+        0
+      ),
     [currentProcedures]
   );
 
@@ -102,9 +106,16 @@ export const MarketSizeOverview: React.FC<MarketSizeOverviewProps> = ({
   
   // Calculate average growth rate
   const averageGrowthRate = useMemo(() => {
-    const procedures = currentProcedures.filter(p => p.yearly_growth_percentage != null);
+    const procedures = currentProcedures.filter(
+      p => p.yearly_growth_percentage != null
+    );
     if (procedures.length === 0) return null;
-    return procedures.reduce((sum, p) => sum + (p.yearly_growth_percentage || 0), 0) / procedures.length;
+    return (
+      procedures.reduce(
+        (sum, p) => sum + (Number(p.yearly_growth_percentage) || 0),
+        0
+      ) / procedures.length
+    );
   }, [currentProcedures]);
   
   // Calculate category market sizes
@@ -113,7 +124,7 @@ export const MarketSizeOverview: React.FC<MarketSizeOverviewProps> = ({
     
     currentProcedures.forEach(p => {
       const category = p.category || p.clinical_category || 'Unknown';
-      const size = p.market_size_usd_millions || 0;
+      const size = Number(p.market_size_usd_millions) || 0;
       categories.set(category, (categories.get(category) || 0) + size);
     });
     


### PR DESCRIPTION
## Summary
- calculate market totals and category data with `Number()` to handle string values

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*