### PR TITLE
Fix progress bar animation

### DIFF
--- a/src/components/Dashboard/MarketSizeOverview.tsx
+++ b/src/components/Dashboard/MarketSizeOverview.tsx
@@ -67,10 +67,13 @@ const formatGrowthRate = (rate: number | null | undefined): string => {
   return `${rate > 0 ? '+' : ''}${rate.toFixed(1)}%`;
 };
 
+// Animation for pulsing effect on progress bars
+// Avoid modifying the `transform` property so it doesn't
+// interfere with LinearProgress's width calculations
 const pulse = keyframes`
-  0% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.7; transform: scale(0.96); }
-  100% { opacity: 1; transform: scale(1); }
+  0% { opacity: 1; }
+  50% { opacity: 0.7; }
+  100% { opacity: 1; }
 `;
 
 export const MarketSizeOverview: React.FC<MarketSizeOverviewProps> = ({ 


### PR DESCRIPTION
## Summary
- avoid overriding LinearProgress bar transform when pulsing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*